### PR TITLE
Fix typos in posts

### DIFF
--- a/src/content/posts/apple-carousel.md
+++ b/src/content/posts/apple-carousel.md
@@ -9,7 +9,7 @@ I wanted to recreate this:
 
 Here's the [resulting code](https://github.com/onsclom/apple-carousel-remake) and a
 [live preview](https://apple-carousel-remake.vercel.app/) (best used on desktop). Using Svelte and
-Tailwind, the recreation experience was suprisingly easy and fun.
+Tailwind, the recreation experience was surprisingly easy and fun.
 
 It's not perfect:
 

--- a/src/content/posts/great-documentation.md
+++ b/src/content/posts/great-documentation.md
@@ -14,7 +14,7 @@ things. Great documentation is **official**, **interactive**, and **open-source*
 The people who make a tool should officially endorse great documentation. Or even better, they
 should work closely with the documentation writers. Or best case scenario, the people who make the
 tool also write documentation! Good documentation should show exactly how a tool was made to be
-used. The official webpage of the tool should spark curiousity. The official webpage should make it
+used. The official webpage of the tool should spark curiosity. The official webpage should make it
 easy to start learning.
 
 ## Interactive

--- a/src/content/posts/immediate-feedback.md
+++ b/src/content/posts/immediate-feedback.md
@@ -8,7 +8,7 @@ hard. Why is this? Games give **immediate feedback**. Game developers add
 [game juice](https://garden.bradwoods.io/notes/design/juice) to maximize feedback per input. If you
 aren’t careful, programming becomes the opposite. I’ll start with an example of a bad feedback loop.
 
-My first programming course in university taught us C++. For coding assigments we were instructed
+My first programming course in university taught us C++. For coding assignments we were instructed
 to: `ssh` into university server, `nano main.cpp`, edit our code (without any syntax highlighting or
 linting), save, exit nano, `g++ main.cpp`, then `./a.out`. Needless to say, we all **hated** doing
 our assignments. Was it good to learn basic unix commands? Sure. Could there have been a better
@@ -20,7 +20,7 @@ nano made things worse. Everything we knew about GUI text editors went out the w
 totally ruined the feedback loop. I believe we could have learned faster and more importantly,
 enjoyed programming, if we used a process that promoted immediate feedback.
 
-19 year old me would be very suprised to hear that I actually enjoy programming now. I do things
+19 year old me would be very surprised to hear that I actually enjoy programming now. I do things
 like [Advent of Code](https://adventofcode.com/), coding puzzles much like my school assignments,
 for fun! Also, I make projects not just for the final product, but because I enjoy the process! I
 believe immediate feedback is the main factor that caused this change. The following are different

--- a/src/content/posts/javascript-tco.md
+++ b/src/content/posts/javascript-tco.md
@@ -5,7 +5,7 @@ pubDate: 2023-09-09
 
 [Bun](https://bun.sh/) is a JavaScript runtime that just released version 1.0! Now you have three
 choices for running JavaScript outside of the browser: Node, Deno, and Bun. One of Bun's selling
-points is speed! It makes some interesting decisions to acheive this.
+points is speed! It makes some interesting decisions to achieve this.
 
 For one, Bun is programmed using [Zig](https://ziglang.org/). This results in an exciting universe:
 Node is made with **C++**, Deno is made with **Rust**, and Bun is made with **Zig**. Isn't this an
@@ -58,7 +58,7 @@ stack size for your program, but there is only so much the OS will allow. Memory
 less restricted. How can we use recursion without fear of exceeding the call stack? The answer: hope
 your JavaScript engine implements TCO and write your recursion in a way that can be optimized!
 
-The process of rewriting a function to be tail call optmized generally involves moving state to
+The process of rewriting a function to be tail call optimized generally involves moving state to
 arguments. The recursive call needs to be the last thing in the function's AST. The TCO version of
 our recursive function looks like:
 
@@ -67,7 +67,7 @@ const count = (amount: number, cur: number[] = []) =>
 	cur.length >= amount ? cur : count(amount, [...cur, cur.length + 1]);
 ```
 
-Its slightly less succint and elegant, but it can be tail call optimized now! If we run
+Its slightly less succinct and elegant, but it can be tail call optimized now! If we run
 `count(100000)` with Deno, we still get
 `error: Uncaught RangeError: Maximum call stack size exceeded`. With Bun, the program now
 successfully runs! But there's still one more problem... This solution is really slow.
@@ -84,7 +84,7 @@ function count(amount: number, cur: number[] = []) {
 }
 ```
 
-This function is starting to look a lot like the orignal for loop solution. It's not very succinct
+This function is starting to look a lot like the original for loop solution. It's not very succinct
 or elegant anymore. But, it runs `count(100000)` at `.01s` as well. Nice!
 
 The minimalist part of me really enjoys TCO. It enables a language to express complex and efficient

--- a/src/content/posts/simulator-state.md
+++ b/src/content/posts/simulator-state.md
@@ -95,7 +95,7 @@ function update(time: number) {
 })();
 ```
 
-We converted our previous `Simulation` into an `Animation`. Instead of maintaing state, we calculate
+We converted our previous `Simulation` into an `Animation`. Instead of maintaining state, we calculate
 positions using just `time`. Not only did we make the code simpler, but we also made the code
 function better!
 


### PR DESCRIPTION
This started from https://twitter.com/HackerNewsZh/status/1741723469430104538, which led me to one of your posts https://www.onsclom.net/posts/javascript-tco, then in which I spot the first typo "acheive".